### PR TITLE
Fix cart user relation

### DIFF
--- a/app/Filament/Resources/CartResource.php
+++ b/app/Filament/Resources/CartResource.php
@@ -35,7 +35,7 @@ public static function form(Form $form): Form
                         ->label('Customer')
                         ->relationship('user', 'name')  // asumsikan model User punya kolom name
                         ->searchable()
-                        ->required(),
+                        ->nullable(),
 
                     // Product (relasi ke products)
                     Forms\Components\Select::make('product_id')

--- a/app/Livewire/Layout/Menu/ProductDetails.php
+++ b/app/Livewire/Layout/Menu/ProductDetails.php
@@ -7,6 +7,9 @@ use App\Models\Product;
 use App\Models\ProductAddon;
 use App\Models\Rating;
 use App\Models\VarianProduct;
+use App\Models\Cart;
+use App\Models\CartAddon;
+use Illuminate\Support\Facades\Auth;
 
 class ProductDetails extends Component
 {
@@ -100,17 +103,30 @@ class ProductDetails extends Component
 
     public function addToCart()
     {
-        $cartItem = [
-            'product' => $this->product,
-            'variant' => $this->variant,
+        $cart = Cart::create([
+            'user_id' => Auth::id(),
+            'product_id' => $this->product->id,
             'quantity' => $this->quantity,
-            'add_ons' => $this->selectedAddOns,
-            'total_price' => $this->totalPrice
-        ];
+            'price' => $this->totalPrice,
+        ]);
+
+        foreach ($this->selectedAddOns as $key) {
+            if (isset($this->addOns[$key])) {
+                $addon = $this->addOns[$key];
+
+                CartAddon::create([
+                    'cart_id' => $cart->id,
+                    'product_addon_id' => ProductAddon::where('name', $addon['name'])->value('id'),
+                    'name' => $addon['name'],
+                    'price' => $addon['price'],
+                    'quantity' => 1,
+                ]);
+            }
+        }
 
         session()->flash('message', 'Item berhasil ditambahkan ke keranjang!');
 
-        return redirect('/cart'); // langsung redirect
+        return redirect('/cart');
     }
 
     public function render() 

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -16,7 +16,7 @@ class Cart extends Model
 
     public function user()
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class)->withDefault();
     }
 
     public function product()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Cart;
 
 class User extends Authenticatable
 {
@@ -43,5 +44,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function carts()
+    {
+        return $this->hasMany(Cart::class);
     }
 }

--- a/database/migrations/2025_06_11_024827_alter_user_id_nullable_in_carts_table.php
+++ b/database/migrations/2025_06_11_024827_alter_user_id_nullable_in_carts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->unsignedBigInteger('user_id')->nullable()->change();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->unsignedBigInteger('user_id')->nullable(false)->change();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- make cart's user relation optional
- persist cart and addons when selecting "MASUK KERANJANG"
- alter `user_id` column in `carts` table so it can be null

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_b_6848ec504fd8832285b1e3028a23d85f