### PR TITLE
Fix footer missing on quantity change

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -170,7 +170,9 @@
 
         {{ $slot }}
 
-        @livewire('layout.footer')
+        <div wire:ignore>
+            @livewire('layout.footer')
+        </div>
     </div>
 
     {{-- Bootstrap Bundle --}}


### PR DESCRIPTION
## Summary
- prevent Livewire updates from removing footer

## Testing
- `php artisan test` *(fails: Vite manifest missing)*

------
https://chatgpt.com/codex/tasks/task_b_68493c52091c8322b6a99e0e30ae9a21